### PR TITLE
Containerize microservices with Docker Compose and Nginx

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,66 @@
+# Testing Instructions
+
+This project includes a Docker Compose setup to run the microservices with an Nginx reverse proxy.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Running the Services
+
+1.  Build and start the containers:
+    ```bash
+    docker compose up -d --build
+    ```
+
+2.  Verify the services are running:
+    ```bash
+    docker compose ps
+    ```
+
+## Testing the Endpoints
+
+The Nginx server exposes port 80. You can access the caller services via the following paths:
+
+### Caller Feign Client
+- **URL**: `http://localhost/caller_feign_client/annotation/lower/{param}`
+- **Example**:
+    ```bash
+    curl http://localhost/caller_feign_client/annotation/lower/TEST
+    ```
+- **Expected Output**: `test` (converted to lowercase)
+
+### Caller Rest Template
+- **URL**: `http://localhost/caller_rest_template/rest_template_client_router/{param}`
+- **Example**:
+    ```bash
+    curl http://localhost/caller_rest_template/rest_template_client_router/TEST
+    ```
+- **Expected Output**: `test`
+
+### Caller Web Client
+- **URL**: `http://localhost/caller_web_client/web_client_annotation/{param}`
+- **Example**:
+    ```bash
+    curl http://localhost/caller_web_client/web_client_annotation/TEST
+    ```
+- **Expected Output**: `test`
+
+## Verifying Security
+
+The responder services are not directly accessible from the host.
+
+- Trying to access a responder directly should fail or be blocked by Nginx:
+    ```bash
+    curl -I http://localhost/responder/
+    curl -I http://localhost/responder_mvc_annotation/
+    ```
+- **Expected Output**: `403 Forbidden` or `404 Not Found` (depending on Nginx config match).
+
+## Stopping the Services
+
+To stop and remove the containers:
+```bash
+docker compose down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+version: '3.8'
+
+services:
+  # Responders (Internal only)
+  responder-annotation:
+    build:
+      context: microservices/responder_mvc_annotation
+    networks:
+      - internal-net
+
+  responder-router:
+    build:
+      context: microservices/responder_mvc_router
+    networks:
+      - internal-net
+
+  responder-webflux:
+    build:
+      context: microservices/responder_webflux
+    networks:
+      - internal-net
+
+  # Callers (Internal only, exposed via Nginx)
+  caller-feign:
+    build:
+      context: microservices/caller_feign_client
+    environment:
+      - RESPONDER_URL=http://responder-annotation:9080
+    depends_on:
+      - responder-annotation
+    networks:
+      - internal-net
+
+  caller-rest:
+    build:
+      context: microservices/caller_rest_template
+    environment:
+      - RESPONDER_URL=http://responder-router:9081
+    depends_on:
+      - responder-router
+    networks:
+      - internal-net
+
+  caller-web:
+    build:
+      context: microservices/caller_web_client
+    environment:
+      - RESPONDER_URL=http://responder-webflux:9082
+    depends_on:
+      - responder-webflux
+    networks:
+      - internal-net
+
+  # Nginx (Public entry point)
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./microservices/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    depends_on:
+      - caller-feign
+      - caller-rest
+      - caller-web
+    networks:
+      - internal-net
+
+networks:
+  internal-net:
+    driver: bridge

--- a/microservices/caller_feign_client/Dockerfile
+++ b/microservices/caller_feign_client/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/microservices/caller_feign_client/src/main/java/org/example/caller/FeignResponderClient.java
+++ b/microservices/caller_feign_client/src/main/java/org/example/caller/FeignResponderClient.java
@@ -4,7 +4,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "responder", url = "http://localhost:9080", path = "/responder_mvc_annotation")
+@FeignClient(name = "responder", url = "${responder.url}", path = "/responder_mvc_annotation")
 public interface FeignResponderClient {
     @GetMapping("/annotation/lower/{param}")
     String annotationConvertLower(@PathVariable String param);

--- a/microservices/caller_feign_client/src/main/resources/application.properties
+++ b/microservices/caller_feign_client/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=8080
 server.servlet.context-path=/caller_feign_client
+responder.url=http://localhost:9080

--- a/microservices/caller_rest_template/Dockerfile
+++ b/microservices/caller_rest_template/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/microservices/caller_rest_template/src/main/java/org/example/caller/CallController.java
+++ b/microservices/caller_rest_template/src/main/java/org/example/caller/CallController.java
@@ -1,5 +1,6 @@
 package org.example.caller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,8 +10,11 @@ import org.springframework.web.client.RestTemplate;
 public class CallController {
     private final RestTemplate restTemplate = new RestTemplate();
 
+    @Value("${responder.url}")
+    private String responderUrl;
+
     @GetMapping("/rest_template_client_router/{param}")
     public String restTemplateToRouter(@PathVariable String param) {
-        return restTemplate.getForObject("http://localhost:9081/responder_mvc_router/router/lower/{param}", String.class, param);
+        return restTemplate.getForObject(responderUrl + "/responder_mvc_router/router/lower/{param}", String.class, param);
     }
 }

--- a/microservices/caller_rest_template/src/main/resources/application.properties
+++ b/microservices/caller_rest_template/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=8081
 server.servlet.context-path=/caller_rest_template
+responder.url=http://localhost:9081

--- a/microservices/caller_web_client/Dockerfile
+++ b/microservices/caller_web_client/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/microservices/caller_web_client/pom.xml
+++ b/microservices/caller_web_client/pom.xml
@@ -39,11 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-openfeign</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/microservices/caller_web_client/src/main/java/org/example/caller/CallController.java
+++ b/microservices/caller_web_client/src/main/java/org/example/caller/CallController.java
@@ -1,5 +1,6 @@
 package org.example.caller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,8 +10,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class CallController {
     private final WebClient webClient;
 
-    public CallController() {
-        this.webClient = WebClient.builder().baseUrl("http://localhost:9082").build();
+    public CallController(@Value("${responder.url}") String responderUrl) {
+        this.webClient = WebClient.builder().baseUrl(responderUrl).build();
     }
 
     @GetMapping("/web_client_annotation/{param}")

--- a/microservices/caller_web_client/src/main/java/org/example/caller/CallerServiceApplication.java
+++ b/microservices/caller_web_client/src/main/java/org/example/caller/CallerServiceApplication.java
@@ -2,9 +2,7 @@ package org.example.caller;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@EnableFeignClients
 @SpringBootApplication
 public class CallerServiceApplication {
     public static void main(String[] args) {

--- a/microservices/caller_web_client/src/main/resources/application.properties
+++ b/microservices/caller_web_client/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=8082
 server.servlet.context-path=/caller_web_client
+responder.url=http://localhost:9082

--- a/microservices/nginx.conf
+++ b/microservices/nginx.conf
@@ -6,46 +6,66 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
 
-    # Define Upstreams (maps to your internal service names)
-    upstream caller_service {
-        server caller:8080;
+    # Callers
+    upstream caller_feign {
+        server caller-feign:8080;
     }
 
-    upstream responder_service {
-        server responder:8080;
+    upstream caller_rest {
+        server caller-rest:8081;
+    }
+
+    upstream caller_web {
+        server caller-web:8082;
     }
 
     server {
         listen 80;
         server_name localhost;
 
-        # ======================================================
-        # 1. PUBLIC API: The Caller Service
-        # ======================================================
-        # This is open to the internet.
-        location /caller/ {
-            proxy_pass http://caller_service;
-
-            # Standard Proxy Headers
+        # Callers
+        location /caller_feign_client/ {
+            proxy_pass http://caller_feign;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # ======================================================
-        # 2. PRIVATE API: The Responder Service
-        # ======================================================
-        # We explicitly block external access to this path.
-        location /responder/ {
-            # Option A: 'deny all' returns 403 Forbidden
-            deny all;
-            return 403;
-
-            # Option B: 'internal' allows access ONLY from internal Nginx redirects
-            # internal;
+        location /caller_rest_template/ {
+            proxy_pass http://caller_rest;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # Health check (optional)
+        location /caller_web_client/ {
+            proxy_pass http://caller_web;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # Block responders
+        location /responder/ {
+            deny all;
+            return 403;
+        }
+
+        location /responder_mvc_annotation/ {
+            deny all;
+            return 403;
+        }
+
+        location /responder_mvc_router/ {
+            deny all;
+            return 403;
+        }
+
+        location /responder_webflux/ {
+            deny all;
+            return 403;
+        }
+
         location /health {
             return 200 '{"status":"UP"}';
             add_header Content-Type application/json;

--- a/microservices/responder_mvc_annotation/Dockerfile
+++ b/microservices/responder_mvc_annotation/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/microservices/responder_mvc_router/Dockerfile
+++ b/microservices/responder_mvc_router/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/microservices/responder_webflux/Dockerfile
+++ b/microservices/responder_webflux/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
This PR containerizes the microservices application using Docker Compose. It includes:
1.  **Dockerfiles**: Added for all caller and responder services using a multi-stage build (Maven + OpenJDK).
2.  **Configuration Updates**: Modified Java code in caller services to use `${responder.url}` property instead of hardcoded `localhost` URLs. This allows injecting the internal Docker service names.
3.  **Nginx Configuration**: Updated `nginx.conf` to proxy requests to the caller services (`/caller_feign_client/`, `/caller_rest_template/`, `/caller_web_client/`) and explicitly block access to responder services.
4.  **Docker Compose**: Created `docker-compose.yml` defining all services and Nginx. Responders are internal-only; Callers are internal but exposed via Nginx.
5.  **Documentation**: Added `TESTING.md` with setup and verification steps.

---
*PR created automatically by Jules for task [6651652941363348602](https://jules.google.com/task/6651652941363348602) started by @ahmedyarub*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new container/runtime topology and request routing changes (Nginx + Compose) that can break service connectivity or unintentionally expose/block endpoints if misconfigured.
> 
> **Overview**
> Adds a Docker-based runtime for the microservices: new multi-stage `Dockerfile`s for each caller/responder service and a top-level `docker-compose.yml` that runs them on an internal bridge network with Nginx as the only host-exposed entrypoint.
> 
> Updates caller services to remove hardcoded `localhost` responder URLs and instead read `${responder.url}` (injected via properties/env), and revises `microservices/nginx.conf` to proxy the three caller context paths while explicitly denying direct access to responder routes. Includes new `TESTING.md` with compose startup, curl examples, and verification steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e72093c98f6ddb6536d47ffbe32a26e4e07d1dca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->